### PR TITLE
Switch to automatic scaling

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -14,6 +14,4 @@ libraries:
 - name: ssl
   version: latest
 
-basic_scaling:
-  max_instances: 1
-  idle_timeout: 10s
+instance_class: F1


### PR DESCRIPTION
As the app is set up now, adding higher-frequency ticks (e.g. every minute) costs money to run, because basic scaling provides only eight hours a day of free usage, and App Engine doesn't provide sub-minute granularity in its charging for instance time.

This switches to automatic scaling and an F1 machine. Although it will be up slightly more often if users are only doing slow ticks, for faster ticks it will be free (28 hours free quota) whereas the charges with basic scaling on B2 add up to more than a dollar a day for users doing a tick every minute.