### PR TITLE
Making sure only admins and cron can use the URL

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -3,6 +3,13 @@ api_version: 1
 threadsafe: true
 
 handlers:
+
+# Handler for the pubsub cron.
+- url: /publish/.*
+  script: main.app
+  login: admin
+  secure: always
+
 - url: /.*
   script: main.app
 


### PR DESCRIPTION
Restricting the /publish/.* URLs to admins (which the cron job is) to make sure this can only be triggered by cron and admins.