### PR TITLE
Add setup.cfg

### DIFF
--- a/appengine/setup.cfg
+++ b/appengine/setup.cfg
@@ -1,0 +1,2 @@
+[install]
+prefix=


### PR DESCRIPTION
It will fix following problem. Thanks.

```
$ pip install -t lib -r requirements.txt
Collecting google-api-python-client (from -r requirements.txt (line 1))
  Using cached google_api_python_client-1.6.5-py2.py3-none-any.whl
Collecting six<2dev,>=1.6.1 (from google-api-python-client->-r requirements.txt (line 1))
  Using cached six-1.11.0-py2.py3-none-any.whl
Collecting httplib2<1dev,>=0.9.2 (from google-api-python-client->-r requirements.txt (line 1))
Collecting uritemplate<4dev,>=3.0.0 (from google-api-python-client->-r requirements.txt (line 1))
  Using cached uritemplate-3.0.0-py2.py3-none-any.whl
Collecting oauth2client<5.0.0dev,>=1.5.0 (from google-api-python-client->-r requirements.txt (line 1))
  Using cached oauth2client-4.1.2-py2.py3-none-any.whl
Collecting rsa>=3.1.4 (from oauth2client<5.0.0dev,>=1.5.0->google-api-python-client->-r requirements.txt (line 1))
  Using cached rsa-3.4.2-py2.py3-none-any.whl
Collecting pyasn1-modules>=0.0.5 (from oauth2client<5.0.0dev,>=1.5.0->google-api-python-client->-r requirements.txt (line 1))
  Using cached pyasn1_modules-0.2.1-py2.py3-none-any.whl
Collecting pyasn1>=0.1.7 (from oauth2client<5.0.0dev,>=1.5.0->google-api-python-client->-r requirements.txt (line 1))
  Using cached pyasn1-0.4.2-py2.py3-none-any.whl
Installing collected packages: six, httplib2, uritemplate, pyasn1, rsa, pyasn1-modules, oauth2client, google-api-python-client
Exception:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/usr/local/lib/python2.7/site-packages/pip/commands/install.py", line 342, in run
    prefix=options.prefix_path,
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_set.py", line 784, in install
    **kwargs
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_install.py", line 851, in install
    self.move_wheel_files(self.source_dir, root=root, prefix=prefix)
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_install.py", line 1064, in move_wheel_files
    isolated=self.isolated,
  File "/usr/local/lib/python2.7/site-packages/pip/wheel.py", line 247, in move_wheel_files
    prefix=prefix,
  File "/usr/local/lib/python2.7/site-packages/pip/locations.py", line 153, in distutils_scheme
    i.finalize_options()
  File "/usr/local/Cellar/python/2.7.14_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/command/install.py", line 264, in finalize_options
    "must supply either home or prefix/exec-prefix -- not both"
DistutilsOptionError: must supply either home or prefix/exec-prefix -- not both
```