### PR TITLE
Minor spelling tense correction

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -16,5 +16,5 @@ var functions = require('firebase-functions');
 
 exports.hourly_job =
   functions.pubsub.topic('hourly-tick').onPublish((event) => {
-    console.log("This job is ran every hour!")
+    console.log("This job is run every hour!")
   });


### PR DESCRIPTION
Tense is base form of word. [See this for more info](https://www.quora.com/Which-is-more-grammatically-correct-was-run-or-was-ran)